### PR TITLE
Create `~/Library/QuickLook` before installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all: ExeLook.qlgenerator
 
 install: all
+	mkdir -p ~/Library/QuickLook
 	cp -r ExeLook.qlgenerator ~/Library/QuickLook
 	qlmanage -r
 


### PR DESCRIPTION
`~/Library/QuickLook` does not exist on a vanilla installation of macOS. Thus, the command `cp -r ExeLook.qlgenerator ~/Library/QuickLook` (executed as a part of `make install`) creates a new directory `QuickLook`  containing the contents of `ExeLook.qlgenerator`, not `ExeLook.qlgenerator` as a whole. 

This pull request fixes this issue by creating `~/Library/QuickLook` first.